### PR TITLE
Fix #18-Stack overflow in VirtualExplorerTree/VirtualTreeView

### DIFF
--- a/Source/VirtualExplorerTree.pas
+++ b/Source/VirtualExplorerTree.pas
@@ -5214,7 +5214,7 @@ begin
     WaitCursor(True);
     try
       BeginUpdate;
-      if ChildCount[Node] = 0 then
+      if Node.ChildCount = 0 then
       begin
         if ValidateNamespace(Node, NS) then
         begin
@@ -5247,7 +5247,7 @@ begin
             { there is no children.                                                   }
             if Node.ChildCount > 0 then
               Sort(Node, Header.SortColumn, Header.SortDirection, False);
-            Result := ChildCount[Node];
+            Result := Node.ChildCount;
 
             if ThreadedEnum and not (csDesigning in ComponentState) then
               EnumThreadFinished;


### PR DESCRIPTION
This PR fixes the stack overflow issue #18 for me. Possibly the same as #17.
I didn't check for further implications. Those were the only two places where ChildCount[Node] was used instead of Node.ChildCount. I don't know if intentionally or just left over.